### PR TITLE
adds ChargifyPricePoint  to retrieve price points. need array support

### DIFF
--- a/api.py
+++ b/api.py
@@ -22,6 +22,8 @@ Author: Paul Trippett (paul@pyhub.com)
 import httplib
 import base64
 import datetime
+from decimal import Decimal
+
 import iso8601
 from itertools import chain
 from xml.dom import minidom
@@ -161,6 +163,8 @@ class ChargifyBase(object):
                                     iso8601.parse(node_value))
                             elif node_type.nodeValue == 'integer':
                                 node_value = int(node_value)
+                            elif node_type.nodeValue == 'decimal':
+                                node_value = Decimal(node_value)
                     elif obj.__single_value_attribute_types__.has_key(childnodes.nodeName) :
                         node_value = obj.__single_value_attribute_types__.get(childnodes.nodeName)(node_value)
 

--- a/api.py
+++ b/api.py
@@ -643,6 +643,46 @@ class ChargifyComponent(ChargifyBase):
                                       ".xml"), self.__name__, 'component')
 
 
+class ChargifyPrice(ChargifyBase):
+    # TODO: not used, this could be the object type of each array element
+    __name__ = 'ChargifyPrice'
+    __attribute_types__ = {}
+    __xmlnodename__ = 'price'
+
+    id = None
+    component_id = None
+    starting_quantity = ''
+    ending_quantity = ''
+    unit_price = ''
+    price_point_id = None
+    formatted_unit_price = ''
+
+    def __init__(self, apikey, subdomain, nodename=''):
+        super(ChargifyPrice, self).__init__(apikey, subdomain)
+        if nodename:
+            self.__xmlnodename__ = nodename
+
+
+class ChargifyPricePoint(ChargifyBase):
+    __name__ = 'ChargifyPricePoint'
+    __attribute_types__ = {
+        # 'prices': 'ChargifyPrice' # TODO: show prices array, each element should be ChargifyPrice?
+    }
+    __xmlnodename__ = 'price_point'
+
+    def __init__(self, apikey, subdomain, nodename=''):
+        super(ChargifyPricePoint, self).__init__(apikey, subdomain)
+        if nodename:
+            self.__xmlnodename__ = nodename
+
+    def get_by_component_id(self,component_id):
+        return self._applyA(
+            self._get("/components/" + str(component_id) + "/price_points.xml"),
+            self.__name__,
+            "price_point"
+        )
+
+
 class ChargifyTransaction(ChargifyBase):
     
     __name__ = 'ChargifyTransaction'
@@ -803,6 +843,9 @@ class Chargify:
 
     def Component(self, nodename=''):
         return ChargifyComponent(self.api_key, self.sub_domain, nodename)
+
+    def PricePoint(self, nodename=''):
+        return ChargifyPricePoint(self.api_key, self.sub_domain, nodename)
 
     def CreditCard(self, nodename=''):
         return ChargifyCreditCard(self.api_key, self.sub_domain, nodename)

--- a/api.py
+++ b/api.py
@@ -655,7 +655,6 @@ class ChargifyComponent(ChargifyBase):
 
 
 class ChargifyPrice(ChargifyBase):
-    # TODO: not used, this could be the object type of each array element
     __name__ = 'ChargifyPrice'
     __attribute_types__ = {}
     __xmlnodename__ = 'price'
@@ -677,7 +676,7 @@ class ChargifyPrice(ChargifyBase):
 class ChargifyPricePoint(ChargifyBase):
     __name__ = 'ChargifyPricePoint'
     __attribute_types__ = {
-        # 'prices': 'ChargifyPrice' # TODO: show prices array, each element should be ChargifyPrice?
+        'prices': 'ChargifyPrice'
     }
     __xmlnodename__ = 'price_point'
 

--- a/api.py
+++ b/api.py
@@ -99,7 +99,7 @@ class ChargifyBase(object):
     """
     __ignore__ = ['api_key', 'sub_domain', 'base_host', 'request_host',
         'id', '__xmlnodename__']
-    
+
     __single_value_attribute_types__ = {}
 
     api_key = ''
@@ -144,6 +144,13 @@ class ChargifyBase(object):
                         self._applyS(childnodes.toxml(),
                         self.__attribute_types__[childnodes.nodeName],
                             childnodes.nodeName))
+                elif "type" in  childnodes.attributes.keys() and childnodes.attributes["type"] == "array" :
+                    children = list()
+                    for subChildNode in childnodes.childNodes :
+                        children.apend(self.__get_object_from_node(subChildNode, subChildNode.nodeName))
+
+                    obj.__setattr__(childnodes.nodeName, children)
+
                 else:
                     node_value = self.__get_xml_value(childnodes.childNodes)
                     if "type" in  childnodes.attributes.keys():
@@ -156,7 +163,7 @@ class ChargifyBase(object):
                                 node_value = int(node_value)
                     elif obj.__single_value_attribute_types__.has_key(childnodes.nodeName) :
                         node_value = obj.__single_value_attribute_types__.get(childnodes.nodeName)(node_value)
-                        
+
                     obj.__setattr__(childnodes.nodeName, node_value)
         return obj
 
@@ -296,18 +303,18 @@ class ChargifyBase(object):
 
         # Unprocessable Entity Error
         elif response.status == 422:
-            
+
             error = ChargifyUnProcessableEntity()
             xml = response.read()
             if xml :
                 dom = minidom.parseString(self.fix_xml_encoding(xml))
                 error.errors = []
                 for errorNodes in dom.childNodes :
-                    
+
                     for errorNode in errorNodes.childNodes :
-                        
+
                         error.errors.append(errorNode.firstChild.data)
-                
+
             raise error
 
         # Generic Server Errors
@@ -558,7 +565,7 @@ class ChargifySubscription(ChargifyBase):
         
         @param product_handle: the new product
         """
-        
+
         xml = """<?xml version="1.0" encoding="UTF-8"?>
 <subscription>
   <product_handle>%s</product_handle>
@@ -684,7 +691,7 @@ class ChargifyPricePoint(ChargifyBase):
 
 
 class ChargifyTransaction(ChargifyBase):
-    
+
     __name__ = 'ChargifyTransaction'
     __attribute_types__ = {}
     __single_value_attribute_types__ = {
@@ -695,7 +702,7 @@ class ChargifyTransaction(ChargifyBase):
         "subscription_id" : int
     }
     __xmlnodename__ = 'transaction'
-    
+
     transaction_type = None
     id = None
     amount_in_cents = None
@@ -710,13 +717,13 @@ class ChargifyTransaction(ChargifyBase):
     kind = None
     gateway_transaction_id = None
     gateway_order_id = None
-    
+
     def getByCustomerId(self, customer_id):
         return self._applyA(self._get('/subscriptions/' + str(customer_id) +
             '/transactions.xml'), self.__name__, 'transaction')
 
 class ChargifyMigration(ChargifyBase):
-    
+
     __name__ = 'ChargifyMigration'
     __attribute_types__ = {}
     __single_value_attribute_types__ = {
@@ -726,7 +733,7 @@ class ChargifyMigration(ChargifyBase):
         "credit_applied_in_cents" : int
     }
     __xmlnodename__ = 'migration'
-    
+
     prorated_adjustment_in_cents = None
     charge_in_cents = None
     payment_due_in_cents = None

--- a/api.py
+++ b/api.py
@@ -146,10 +146,10 @@ class ChargifyBase(object):
                         self._applyS(childnodes.toxml(),
                         self.__attribute_types__[childnodes.nodeName],
                             childnodes.nodeName))
-                elif "type" in  childnodes.attributes.keys() and childnodes.attributes["type"] == "array" :
+                elif "type" in  childnodes.attributes.keys() and childnodes.attributes["type"].nodeValue == "array" :
                     children = list()
                     for subChildNode in childnodes.childNodes :
-                        children.apend(self.__get_object_from_node(subChildNode, subChildNode.nodeName))
+                        children.append(self.__get_object_from_node(subChildNode, self.__attribute_types__.get(subChildNode.nodeName)))
 
                     obj.__setattr__(childnodes.nodeName, children)
 
@@ -676,7 +676,7 @@ class ChargifyPrice(ChargifyBase):
 class ChargifyPricePoint(ChargifyBase):
     __name__ = 'ChargifyPricePoint'
     __attribute_types__ = {
-        'prices': 'ChargifyPrice'
+        'price': 'ChargifyPrice'
     }
     __xmlnodename__ = 'price_point'
 


### PR DESCRIPTION
**Do not merge**!.  I'm not sure if we need ChargifyPrice class for each of the array elements (depends on how we add supports for arrays)

so far ChargifyPricePoint works, but the field 'prices' is empty it should be an array with the prices data.

test it in our sandbox using: `BillingService().chargify.PricePoint().get_by_component_id(459522)`